### PR TITLE
Adding MockHTTPAdapter for test/dev modes

### DIFF
--- a/lib/delighted.rb
+++ b/lib/delighted.rb
@@ -25,19 +25,51 @@ require 'delighted/resources/unsubscribe'
 require 'delighted/errors'
 require 'delighted/http_response'
 require 'delighted/http_adapter'
+require 'delighted/mock_http_adapter'
 require 'delighted/client'
 
 module Delighted
   @mutex = Mutex.new
 
   class << self
-    attr_accessor :api_key, :api_base_url, :http_adapter
-    attr_writer :shared_client
+    attr_accessor :api_key, :api_base_url
+    attr_writer :http_adapter, :shared_client, :test_mode
+
+    #
+    # We override the setting to return a MockHTTPAdapter
+    # if we are in test mode
+    #
+    def http_adapter
+      if self.test_mode?
+        self.mock_http_adapter
+      else
+        @http_adapter
+      end
+    end
 
     def shared_client
       @mutex.synchronize do
         @shared_client ||= Client.new(:api_key => api_key, :api_base_url => api_base_url, :http_adapter => http_adapter)
       end
     end
+
+    #
+    # Are we currently in test mode?
+    #
+    # @return [Boolean]
+    def test_mode
+      @test_mode ||= false
+    end
+    alias_method :test_mode?, :test_mode
+
+    protected
+
+    #
+    # Hold on to an instance of a MockHTTPAdapter
+    #
+    def mock_http_adapter
+      @mock_http_adapter ||= ::Delighted::MockHTTPAdapter.new
+    end
+
   end
 end

--- a/lib/delighted/client.rb
+++ b/lib/delighted/client.rb
@@ -3,6 +3,12 @@ module Delighted
     DEFAULT_API_BASE_URL = "https://api.delightedapp.com/v1"
     DEFAULT_HTTP_ADAPTER = HTTPAdapter.new
 
+    #
+    # This is just here for testing really, but it lets us have
+    # access to the adapter instance
+    #
+    attr_reader :http_adapter
+
     def initialize(opts = {})
       @api_key = opts[:api_key] or raise ArgumentError, "You must provide an API key by setting Delighted.api_key = '123abc' or passing { :api_key => '123abc' } when instantiating Delighted::Client.new"
       @api_base_url = opts[:api_base_url] || DEFAULT_API_BASE_URL

--- a/lib/delighted/mock_http_adapter.rb
+++ b/lib/delighted/mock_http_adapter.rb
@@ -1,0 +1,137 @@
+require 'json'
+
+module Delighted
+  #
+  # Class that satisfies the interface of HTTPAdapter
+  # but does not actually make HTTP requests
+  #
+  class MockHTTPAdapter < HTTPAdapter
+    def request(method, uri, headers, data = nil)
+      response = self.build_response(method, headers, data)
+      HTTPResponse.new(response.code, response.headers, response.body)
+    end
+
+    #
+    # Builds an appropriate response we can pass on to the rest of the
+    #
+    def build_response(method, headers, data)
+      case method
+      when :delete
+        MockDelete.new(headers, data)
+      when :get
+        MockGet.new(headers, data)
+      when :post
+        MockPost.new(headers, data)
+      when :put
+        MockPut.new(headers, data)
+      else
+        raise ArgumentError.new("#{method} is not a valid HTTP verb")
+      end
+    end
+  end
+
+  #
+  # Superclass for requests
+  #
+  class MockRequest
+
+    attr_reader :headers, :data
+
+    #
+    # Constructor
+    #
+    # @param headers [Hash]
+    # @param data [Hash, nil]
+    #
+    def initialize(headers, data)
+      @headers, @data = headers, JSON.load(data || '{}')
+    end
+
+    #
+    # Default to a blank body and the headers we sent
+    #
+    def body
+      ""
+    end
+
+    #
+    # Default to 200 (Success)
+    #
+    # @return [Integer]
+    def code
+      200
+    end
+
+    protected
+
+    #
+    # Helper method to generate a unique ID
+    #
+    # @return [Integer]
+    def next_id
+      @counter ||= 0
+      @counter += 1
+    end
+  end
+
+  #
+  # Fake DELETE request
+  #
+  class MockDelete < MockRequest
+    #
+    # Implementation of body
+    #
+    # @return [String]
+    def body
+      JSON.dump(ok: true)
+    end
+  end
+
+  #
+  # Handles GET requests
+  #
+  class MockGet < MockRequest
+  end
+
+  #
+  # Handles POST requests
+  #
+  class MockPost < MockRequest
+    #
+    # Constructor
+    #
+    def initialize(headers, data = '{}')
+      super(headers, data)
+    end
+
+    #
+    # Implementation of #body
+    #
+    # @return [String]
+    def body
+      JSON.dump(@data.merge(id: self.next_id))
+    end
+
+    #
+    # Implementation of #code
+    #
+    # @return [Integer] 201 (Created)
+    def code
+      201
+    end
+  end
+
+  #
+  # Fake PUT request
+  #
+  class MockPut < MockRequest
+    #
+    # Implementation of body
+    #
+    # @return [String]
+    def body
+      JSON.dump(@data || {})
+    end
+  end
+
+end

--- a/test/mock_http_adapter_test.rb
+++ b/test/mock_http_adapter_test.rb
@@ -1,0 +1,84 @@
+require 'test_helper'
+
+class Delighted::MockHTTPAdapterTest < Delighted::TestCase
+
+  def setup
+    super
+    Delighted.api_key = '123abc'
+    Delighted.test_mode = true
+  end
+
+  def teardown
+    super
+    Delighted.api_key = nil
+    Delighted.test_mode = false
+  end
+
+  def adapter
+    @adapter ||= Delighted::MockHTTPAdapter.new
+  end
+
+  def test_adapter_is_mock
+    assert_kind_of(
+      Delighted::MockHTTPAdapter,
+      Delighted.shared_client.http_adapter
+    )
+  end
+
+  def test_get
+    response = adapter.request(:get, '/a/b/c', {})
+    assert_kind_of(
+      Delighted::HTTPResponse,
+      response
+    )
+  end
+
+  def test_delete
+    response = adapter.request(:delete, '/a/b/c', {})
+    assert_kind_of(
+      Delighted::HTTPResponse,
+      response
+    )
+  end
+
+  def test_post
+    response = adapter.request(
+      :post,
+      '/a/b/c',
+      {},
+      JSON.dump({ email: 'test@test.com'})
+    )
+    assert_kind_of(
+      Delighted::HTTPResponse,
+      response
+    )
+    assert_equal(
+      ::JSON.load(response.body)['email'],
+      'test@test.com',
+    )
+  end
+
+  def test_put
+    response = adapter.request(
+      :put,
+      '/a/b/c',
+      {},
+      JSON.dump({ email: 'test@test.com'})
+    )
+    assert_kind_of(
+      Delighted::HTTPResponse,
+      response
+    )
+    assert_equal(
+      ::JSON.load(response.body)['email'],
+      'test@test.com',
+    )
+  end
+
+  def test_create_person
+    person = Delighted::Person.create(email: 'test@test.com')
+    assert_equal(person.email, 'test@test.com')
+    refute_nil(person.id)
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,17 @@ class Delighted::TestCase < Minitest::Test
 
   def setup
     super
-    Delighted.shared_client = Delighted::Client.new(:api_key => '123abc', :http_adapter => mock_http_adapter)
+    Delighted.api_key = '123abc'
+    Delighted.http_adapter = mock_http_adapter
+  end
+
+  def teardown
+    #
+    # Clear our our shared client and all settings
+    #
+    Delighted.shared_client = nil
+    Delighted.api_key = nil
+    Delighted.http_adapter = nil
   end
 
   def mock_http_adapter


### PR DESCRIPTION
I took the approach of creating classes with canned responses based on the HTTP verb provided.   I could imagine adding more specific responses based on the resource being created, which could be done via pattern matching on the URI, but I figured this was a good place to start.  I will have a bit of time to work on this in the next few days if you have any feedback on this PR

cc @mkdynamic 
