### PR TITLE
Remove the terminal newline added by 1.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.1 (Unreleased)
+
+Features:
+
+- Fix authentication header on REE-1.8.7-2011.03
+
 ## 1.3.0 (2014-06-03)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Features:
 
-- Fix authentication header on REE-1.8.7-2011.03
+- Fix authentication header on 1.8.7
 
 ## 1.3.0 (2014-06-03)
 

--- a/lib/delighted/client.rb
+++ b/lib/delighted/client.rb
@@ -60,7 +60,7 @@ module Delighted
 
     def default_headers
       @default_headers ||= {
-        'Authorization' => "Basic #{["#{@api_key}:"].pack('m0')}",
+        'Authorization' => "Basic #{["#{@api_key}:"].pack('m').chomp}",
         'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}"
       }.freeze
     end

--- a/lib/delighted/version.rb
+++ b/lib/delighted/version.rb
@@ -1,3 +1,3 @@
 module Delighted
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/test/delighted_test.rb
+++ b/test/delighted_test.rb
@@ -10,7 +10,7 @@ end
 class Delighted::MetricsTest < Delighted::TestCase
   def test_retrieving_metrics
     uri = URI.parse("https://api.delightedapp.com/v1/metrics")
-    headers = { 'Authorization' => "Basic #{["123abc:"].pack('m0')}", "Accept" => "application/json", 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
+    headers = { 'Authorization' => @auth_header, "Accept" => "application/json", 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
     response = Delighted::HTTPResponse.new(200, {}, Delighted::JSON.dump({ :nps => 10 }))
     mock_http_adapter.expects(:request).with(:get, uri, headers).once.returns(response)
 
@@ -25,7 +25,7 @@ end
 class Delighted::PeopleTest < Delighted::TestCase
   def test_creating_or_updating_a_person
     uri = URI.parse("https://api.delightedapp.com/v1/people")
-    headers = { 'Authorization' => "Basic #{["123abc:"].pack('m0')}", "Accept" => "application/json", 'Content-Type' => 'application/json', 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
+    headers = { 'Authorization' => @auth_header, "Accept" => "application/json", 'Content-Type' => 'application/json', 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
     data = Delighted::JSON.dump({ :email => 'foo@bar.com' })
     response = Delighted::HTTPResponse.new(200, {}, Delighted::JSON.dump({ :id => '123', :email => 'foo@bar.com' }))
     mock_http_adapter.expects(:request).with(:post, uri, headers, data).once.returns(response)
@@ -41,7 +41,7 @@ class Delighted::PeopleTest < Delighted::TestCase
     person_email = 'person@example.com'
     uri = URI.parse('https://api.delightedapp.com/v1/unsubscribes')
     headers = {
-      'Authorization' => "Basic #{["123abc:"].pack('m0')}",
+      'Authorization' => @auth_header,
       'Accept' => 'application/json',
       'Content-Type' => 'application/json',
       'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}"
@@ -57,7 +57,7 @@ class Delighted::PeopleTest < Delighted::TestCase
 
   def test_deleting_pending_survey_requests_for_a_person
     uri = URI.parse("https://api.delightedapp.com/v1/people/foo%40bar.com/survey_requests/pending")
-    headers = { 'Authorization' => "Basic #{["123abc:"].pack('m0')}", "Accept" => "application/json", 'Content-Type' => 'application/json', 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
+    headers = { 'Authorization' => @auth_header, "Accept" => "application/json", 'Content-Type' => 'application/json', 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
     response = Delighted::HTTPResponse.new(200, {}, Delighted::JSON.dump({ :ok => true }))
     mock_http_adapter.expects(:request).with(:delete, uri, headers, nil).once.returns(response)
 
@@ -70,7 +70,7 @@ end
 class Delighted::SurveyResponseTest < Delighted::TestCase
   def test_creating_a_survey_response
     uri = URI.parse("https://api.delightedapp.com/v1/survey_responses")
-    headers = { 'Authorization' => "Basic #{["123abc:"].pack('m0')}", "Accept" => "application/json", 'Content-Type' => 'application/json', 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
+    headers = { 'Authorization' => @auth_header, "Accept" => "application/json", 'Content-Type' => 'application/json', 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
     data = Delighted::JSON.dump({ :person => '123', :score => 10 })
     response = Delighted::HTTPResponse.new(200, {}, Delighted::JSON.dump({ :id => '456', :person => '123', :score => 10 }))
     mock_http_adapter.expects(:request).with(:post, uri, headers, data).once.returns(response)
@@ -85,7 +85,7 @@ class Delighted::SurveyResponseTest < Delighted::TestCase
 
   def test_listing_all_survey_responses
     uri = URI.parse("https://api.delightedapp.com/v1/survey_responses?order=desc")
-    headers = { 'Authorization' => "Basic #{["123abc:"].pack('m0')}", "Accept" => "application/json", 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
+    headers = { 'Authorization' => @auth_header, "Accept" => "application/json", 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
     response = Delighted::HTTPResponse.new(200, {}, Delighted::JSON.dump([{ :id => '123', :comment => 'One' }, { :id => '456', :comment => 'Two' }]))
     mock_http_adapter.expects(:request).with(:get, uri, headers).once.returns(response)
 
@@ -103,7 +103,7 @@ class Delighted::SurveyResponseTest < Delighted::TestCase
 
   def test_listing_all_survey_responses_expand_person
     uri = URI.parse("https://api.delightedapp.com/v1/survey_responses?expand%5B%5D=person")
-    headers = { 'Authorization' => "Basic #{["123abc:"].pack('m0')}", "Accept" => "application/json", 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
+    headers = { 'Authorization' => @auth_header, "Accept" => "application/json", 'User-Agent' => "Delighted RubyGem #{Delighted::VERSION}" }
     response = Delighted::HTTPResponse.new(200, {}, Delighted::JSON.dump([{ :id => '123', :comment => 'One', :person => { :id => '123', :email => 'foo@bar.com' } }, { :id => '456', :comment => 'Two', :person => { :id => '123', :email => 'foo@bar.com' } }]))
     mock_http_adapter.expects(:request).with(:get, uri, headers).once.returns(response)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ class Delighted::TestCase < Minitest::Test
   def setup
     super
     Delighted.shared_client = Delighted::Client.new(:api_key => '123abc', :http_adapter => mock_http_adapter)
+    @auth_header = "Basic #{["123abc:"].pack('m').chomp}"
   end
 
   def mock_http_adapter


### PR DESCRIPTION
The way we are encoding the API key with `Array#pack` has a different behavior in 1.8.7 from 1.9 mode:

```bash
$ RBENV_VERSION=1.8.7-p375 ruby -e "puts ['a'].pack('m0').inspect"
"YQ==\n"
$ RBENV_VERSION=2.0.0-p353 ruby -e "puts ['a'].pack('m0').inspect"
"YQ=="
```

This is consistent with the documentation, which added a note about the omission of a newline when the width is 0 in 1.9.2+:

> ```
> m | String | base64 encoded string (see RFC 2045, count is width) |
> ```
>
> http://ruby-doc.org/core-1.8.7/Array.html#method-i-pack

> ```
> m | String  | base64 encoded string (see RFC 2045, count is width)
>               (if count is 0, no line feed are added, see RFC 4648)
> ```
>
> http://ruby-doc.org/core-1.9.2/Array.html#method-i-pack

The newline means the Host header (added automatically by Net::HTTP) gets ignored, since the HTTP request ends up like:

```
GET /v1/ping.json HTTP/1.1
Accept: */*
Connection: close
Authorization: Basic REDACTED

Host: api.delightedapp.com
```

Made a 1-3-stable branch so we can release just this as a 1.3.1 bugfix without needing to release the additional changes in master.