### PR TITLE
require 'date'

### DIFF
--- a/lib/delighted/utils.rb
+++ b/lib/delighted/utils.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module Delighted
   module Utils
     def self.eigenclass(object)


### PR DESCRIPTION
This fixes the following error we have been seeing:

```
lib/delighted/utils.rb:44:in `serialize_values': uninitialized constant Delighted::Utils::Date (NameError)
```